### PR TITLE
Add zero before hr/min if its less than 10

### DIFF
--- a/Day3/index.html
+++ b/Day3/index.html
@@ -46,7 +46,12 @@
         },
         getCurrentTime() {
             const now = new Date();
-            return now.getHours() + ":" + now.getMinutes()
+            let hr = now.getHours();
+            let min = now.getMinutes();
+            // add a zero in front of numbers<10
+            hr = hr < 10 ? "0" + hr : hr;
+            min = min < 10 ? "0" + min : min;
+            return hr + ":" + min
         }
     }
 </script>


### PR DESCRIPTION
new Date().getHours(), new Date().getMinutes() would return the integer value which omits preceding zero. But, time input value is in hh:mm format, that means it will add a zero if the values are less than 10. As a result, the condition on line 40 would sometime be false.

To fix the issue,  getCurrentTIme() needs to add preceding zero if numbers are leass than 10.